### PR TITLE
Centered the header of Calculator: “Calculator"

### DIFF
--- a/Calculator/cal.css
+++ b/Calculator/cal.css
@@ -29,7 +29,7 @@ button{
 }
 #heading{
     margin: auto;
-    width: 412px;
+    width: 275px;
     font-size: xxx-large;
 }
 #btn{


### PR DESCRIPTION
The calculator header was not centered due to the width being adjusted to high. I lowered the width and now the calculator header is centered on the screen.