### PR TITLE
diabled button when no text on input box

### DIFF
--- a/TODO-LIST/src/App.css
+++ b/TODO-LIST/src/App.css
@@ -46,6 +46,12 @@ input:focus{
   width: 70px;
 }
 
+.btn-addTodo:disabled {
+  cursor: not-allowed; /* Removes the pointer style */
+  background-color: #ccc; /* Optional: make background lighter */
+  color: red; /* Make text red when disabled */
+}
+
 .todo {
   width: 300px;
   padding: 10px;

--- a/TODO-LIST/src/pages/Home.jsx
+++ b/TODO-LIST/src/pages/Home.jsx
@@ -49,12 +49,14 @@ const Home = () => {
         localStorage.setItem('todos', JSON.stringify(todos))
     },[todos])
 
+    const isSubmitDisabled = todo.trim() === '';
+
     return (
     <div className='home'>
       <div className='container'>
           <form className='todo-form' onSubmit={addTodo}>
             <input type="text" placeholder='Add item...' value={todo} onChange={(e) => setTodo(e.target.value)}/>
-            <input type='button' onClick={addTodo} className='btn-addTodo' value='Add' />
+            <input type='button' onClick={addTodo} className='btn-addTodo' value='Add' disabled={isSubmitDisabled} />
           </form>
           {
                 todos.length? (


### PR DESCRIPTION
Issue Title: Disable Add button when input is empty (#77)
Description:
This update addresses the enhancement request to disable the "Add" button when the input field is empty, preventing users from submitting empty todo items. In addition, when the button is disabled, the pointer style will change to indicate the disabled state by showing a red cursor instead of the default pointer cursor.

Changes Implemented:
Button Disabled State:

The "Add" button is now conditionally disabled if the input field is empty or contains only whitespace.
This is achieved by checking the todo state using todo.trim() === ''. If true, the button is disabled.
Custom Styling for Disabled Button:

The disabled button's appearance has been updated to reflect its inactive state.
The cursor changes to a custom red pointer when hovering over the disabled button.
The button's default cursor: pointer behavior is removed when disabled.
CSS for Disabled State:

Added custom CSS rules to style the disabled button:
Changed the cursor to not-allowed and set it to red for better visual feedback.
Additional styles were added to make the button appear visually distinct when disabled (such as reduced opacity or gray text).
Files Modified:
in TODO-LIST folder /
src/Home.jsx: Updated to conditionally disable the submit button based on input value.
app.css: (or relevant stylesheet): Added styles to modify the cursor and appearance of the disabled button.
![github todo](https://github.com/user-attachments/assets/cdc5c79f-6d8f-4df2-83de-9305ce9eb3c2)
![image](https://github.com/user-attachments/assets/1969d963-339c-4cad-a651-05bd35002c10)

