### PR TITLE
fix - link not working

### DIFF
--- a/Temperature-Converter/Js/script.js
+++ b/Temperature-Converter/Js/script.js
@@ -56,14 +56,12 @@ const calculateTemp = () => {
     let result;
     if (valeTemp == "cel") {
         result = celTOfah(numberTemp);
-        document.getElementById('resultContainer').innerHTML = `= ${result}°Fahrenheit`;
+        document.getElementById('resultContainer').innerHTML = `= ${result.toFixed(2)}°Fahrenheit`;
     } else {
         result = fahTOcel(numberTemp);
-        document.getElementById('resultContainer').innerHTML = `= ${result}°Celsius`;
+        document.getElementById('resultContainer').innerHTML = `= ${result.toFixed(2)}°Celsius`;
     }
 
-    setTimeout(() => {
-        window.location.reload();
-    }, 1500);
+    
 }
 


### PR DESCRIPTION
Fixes -
Removed unnecessary page reload after conversion.
Ensured accurate temperature conversion with results displayed to 2 decimal places.