### PR TITLE
Fix: temperature converter decimal precision issue

### DIFF
--- a/Temperature-Converter/Js/script.js
+++ b/Temperature-Converter/Js/script.js
@@ -44,13 +44,13 @@ const calculateTemp = () => {
     // Convert temperature from Celcius to Fahrenheit
     const celTOfah = (cel) => {
         let fahrenheit = (cel * (9 / 5) + 32);
-        return fahrenheit;
+        return fahrenheit.toFixed(2); //only show 2 decimal places
     }
 
     // Convert temperature from Fahrenheit to Celsius
     const fahTOcel = (fehr) => {
         let celsius = ((fehr - 32) * 5 / 9);
-        return celsius;
+        return celsius.toFixed(2); //here also show only 2 decimal places
     }
 
     let result;

--- a/Temperature-Converter/Js/script.js
+++ b/Temperature-Converter/Js/script.js
@@ -25,6 +25,8 @@ const tempLoad = () => {
 }
 
 setInterval(() => {
+    //define the variable fa in this scope to avoid the error of "fa is not defined"
+    const fa =document.getElementById('fa');
     fa.style.color = "#ffa41b";
     tempLoad();
 }, 5000);
@@ -44,13 +46,15 @@ const calculateTemp = () => {
     // Convert temperature from Celcius to Fahrenheit
     const celTOfah = (cel) => {
         let fahrenheit = (cel * (9 / 5) + 32);
-        return fahrenheit.toFixed(2); //only show 2 decimal places
+        //only show 2 decimal places
+        return fahrenheit.toFixed(2); 
     }
 
     // Convert temperature from Fahrenheit to Celsius
     const fahTOcel = (fehr) => {
         let celsius = ((fehr - 32) * 5 / 9);
-        return celsius.toFixed(2); //here also show only 2 decimal places
+        //here also show only 2 decimal places
+        return celsius.toFixed(2);  
     }
 
     let result;

--- a/Temperature-Converter/Js/script.js
+++ b/Temperature-Converter/Js/script.js
@@ -35,11 +35,11 @@ setInterval(() => {
 tempLoad();
 
 const calculateTemp = () => {
-    const numberTemp = document.getElementById('temp').value;
+    const numberTemp = parseFloat(document.getElementById('temp').value);
     // console.log(numberTemp);
 
     const tempSelected = document.querySelector('#temp_diff');
-    const valeTemp = temp_diff.options[tempSelected.selectedIndex].value;
+    const valeTemp = tempSelected.options[tempSelected.selectedIndex].value;
     // console.log(valeTemp);
 
 

--- a/Temperature-Converter/index.html
+++ b/Temperature-Converter/index.html
@@ -33,7 +33,8 @@
         <label for="temp">Please Enter the Temperature you'd like to convert.</label>
         <div class="row my-3">
             <div class="col">
-                <input type="number" step="0.01" id="temp" class="form-control" required> //prevent empty submissions and only allow numbers with up to 2 decimal places.
+                <input type="number" step="0.01" id="temp" class="form-control" required>
+                 //prevent empty submissions and only allow numbers with up to 2 decimal places.
             </div>
             <div class="col">
                 <select name="temp_diff" class="form-control" id="temp_diff">

--- a/Temperature-Converter/index.html
+++ b/Temperature-Converter/index.html
@@ -34,7 +34,6 @@
         <div class="row my-3">
             <div class="col">
                 <input type="number" step="0.01" id="temp" class="form-control" required>
-                 //prevent empty submissions and only allow numbers with up to 2 decimal places.
             </div>
             <div class="col">
                 <select name="temp_diff" class="form-control" id="temp_diff">

--- a/Temperature-Converter/index.html
+++ b/Temperature-Converter/index.html
@@ -33,7 +33,7 @@
         <label for="temp">Please Enter the Temperature you'd like to convert.</label>
         <div class="row my-3">
             <div class="col">
-                <input type="number" step="any" id="temp" class="form-control">
+                <input type="number" step="0.01" id="temp" class="form-control" required> //prevent empty submissions and only allow numbers with up to 2 decimal places.
             </div>
             <div class="col">
                 <select name="temp_diff" class="form-control" id="temp_diff">


### PR DESCRIPTION
This PR fixes issue #121 in the Temperature Converter.

Changes made:
- Limited temperature output to 2 decimal places using toFixed(2)
- Fixed fa variable scope issue in setInterval
- Improved input validation in HTML
- Converted input value to number using parseFloat

These changes improve accuracy and prevent runtime errors.